### PR TITLE
[Backport 1.7] Update dependency c2cciutils to v1.5.5 (1.5)

### DIFF
--- a/BACKPORT_TODO
+++ b/BACKPORT_TODO
@@ -1,0 +1,9 @@
+Error on backporting to branch 1.7, error on cherry picking 52567274c5b487b62444421c954613846aa4e75b:
+
+
+
+To continue do:
+git fetch && git checkout backport/504-to-1.7 && git reset --hard HEAD^
+git cherry-pick 52567274c5b487b62444421c954613846aa4e75b
+git cherry-pick 1fa75484fd89f141435f3d7e72800323e5b578a5
+git push origin backport/504-to-1.7 --force


### PR DESCRIPTION
Backport of #504

Error on cherry picking:
Error on backporting to branch 1.7, error on cherry picking 52567274c5b487b62444421c954613846aa4e75b:



To continue do:
git fetch && git checkout backport/504-to-1.7 && git reset --hard HEAD^
git cherry-pick 52567274c5b487b62444421c954613846aa4e75b
git cherry-pick 1fa75484fd89f141435f3d7e72800323e5b578a5
git push origin backport/504-to-1.7 --force