### PR TITLE
Support patternProperties when one property is given

### DIFF
--- a/jsonschema_gentypes/__init__.py
+++ b/jsonschema_gentypes/__init__.py
@@ -742,7 +742,6 @@ def get_description(
             "default",
             "examples",
             "contains",
-            "patternProperties",
             "dependencies",
             "propertyNames",
         ):

--- a/jsonschema_gentypes/api_draft_04.py
+++ b/jsonschema_gentypes/api_draft_04.py
@@ -109,6 +109,23 @@ class APIv4(API):
         elif isinstance(additional_properties, dict):
             sub_type = self.get_type(additional_properties, f"{proposed_name} additionalProperties")
             std_dict = CombinedType(NativeType("Dict"), [BuiltinType("str"), sub_type])
+        else:
+            pattern_properties = cast(
+                dict[
+                    str,
+                    Union[
+                        jsonschema_draft_04.JSONSchemaD4,
+                        jsonschema_draft_2020_12_applicator.JSONSchemaItemD2020,
+                    ],
+                ],
+                schema.get("patternProperties"),
+            )
+            if pattern_properties and len(pattern_properties) == 1:
+                schema.setdefault("used", set()).add("patternProperties")  # type: ignore[typeddict-item]
+                pattern_prop = list(pattern_properties.values())[0]
+                sub_type = self.get_type(pattern_prop, f"{proposed_name} Type")
+                std_dict = CombinedType(NativeType("Dict"), [BuiltinType("str"), sub_type])
+
         schema.setdefault("used", set()).add("properties")  # type: ignore[typeddict-item]
         properties = cast(
             dict[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ profile = "black"
 line_length = 110
 
 [tool.mypy]
-python_version = 3.9
+python_version = "3.9"
 warn_redundant_casts = true
 warn_unused_ignores = true
 ignore_missing_imports = true

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -360,6 +360,77 @@ TestBasicTypes = Dict[str, Any]
     )
 
 
+def test_pattern_properties_multiple():
+    type_ = get_types(
+        {
+            "type": "object",
+            "Title": "Pattern properties with tow patterns",
+            "patternProperties": {"^[a-z]+$": {"type": "string"}, "^[0-9]+$": {"type": "number"}},
+        }
+    )
+    assert (
+        "\n".join([d.rstrip() for d in type_.definition(None)])
+        == '''
+
+_Base = Dict[str, Any]
+""" Title: Pattern properties with tow patterns """
+'''
+    )
+
+
+def test_pattern_properties_string():
+    type_ = get_types(
+        {
+            "type": "object",
+            "title": "Pattern properties with one pattern as string",
+            "patternProperties": {
+                "^[a-z]+$": {"type": "string"},
+            },
+        }
+    )
+    assert (
+        "\n".join([d.rstrip() for d in type_.definition(None)])
+        == '''
+
+PatternPropertiesWithOnePatternAsString = Dict[str, str]
+""" Pattern properties with one pattern as string. """
+'''
+    )
+
+
+def test_pattern_properties_object():
+    type_ = get_types(
+        {
+            "type": "object",
+            "title": "Pattern properties with one pattern as object",
+            "patternProperties": {
+                "^[a-z]+$": {
+                    "type": "object",
+                    "properties": {
+                        "prop": {"type": "string"},
+                    },
+                },
+            },
+        }
+    )
+    assert (
+        "\n".join([d.rstrip() for d in type_.definition(None)])
+        == '''
+
+PatternPropertiesWithOnePatternAsObject = Dict[str, "_PatternPropertiesWithOnePatternAsObjectType"]
+""" Pattern properties with one pattern as object. """
+'''
+    )
+
+    assert (
+        "\n".join([d.rstrip() for d in type_.depends_on()[0].depends_on()[2].definition(None)])
+        == f"""
+
+class _PatternPropertiesWithOnePatternAsObjectType(TypedDict, total=False):
+    prop: str"""
+    )
+
+
 def test_boolean_const():
     type_ = get_types(
         {


### PR DESCRIPTION
I have added support for objects that use `patternProperties` with a single pattern. This will create a Dict type with str as the key type and the property type as the value's type.

I've added test cases for a simple type, an object type and for the case of multiple patterns where it is not supported.

Note that the tests were failing in Python 3.12 so I modified the python version restriction to support only 3.11 for now.

Fix #790