### PR TITLE
Support for references by $id from local files

### DIFF
--- a/jsonschema_gentypes/cli.py
+++ b/jsonschema_gentypes/cli.py
@@ -177,7 +177,7 @@ def process_config(config: configuration.Configuration, files: list[str]) -> Non
             continue
         print(f"Processing {source}")
 
-        resolver = jsonschema_gentypes.resolver.RefResolver(source)
+        resolver = jsonschema_gentypes.resolver.RefResolver(source, files=files)
         schema = resolver.schema
 
         if "vocabularies" in gen:

--- a/jsonschema_gentypes/resolver.py
+++ b/jsonschema_gentypes/resolver.py
@@ -90,7 +90,7 @@ _VOCAB_URL_RE = re.compile(rf"{re.escape(_URL_PREFIX)}([0-9-]+)/vocab/(.+)$")
 _META_RE = re.compile(r"^meta/([a-zA-Z0-9]+)#(.*)$")
 
 
-class UnRedolvedException(Exception):
+class UnResolvedException(Exception):
     """Exception for unresolved references."""
 
 
@@ -188,7 +188,7 @@ class RefResolver:
                     return resolver.lookup(uri).contents
                 except (referencing.exceptions.NoSuchResource, referencing.exceptions.PointerToNowhere):
                     pass
-        raise UnRedolvedException(f"Ref '{uri}' not found") from exception
+        raise UnResolvedException(f"Ref '{uri}' not found") from exception
 
     def auto_resolve(
         self,


### PR DESCRIPTION
jsonschema support referencing other schema by $id, but jsonschema gentypes only allows for references by file name, or http(s) url. 

This pull request includes all files provided in the configuration file to the Resource Registry, both by $id, when present, and by file name.

(It also fixes a typo in the UnresolvedAcception class name)