### PR TITLE
Fix TypeAlias and mypy comment issues

### DIFF
--- a/jsonschema_gentypes/__init__.py
+++ b/jsonschema_gentypes/__init__.py
@@ -597,11 +597,11 @@ class TypedDictType(NamedType):
                     result.append("")
         else:
             result += [
-                "# " + d for d in split_comment(self.descriptions, line_length - 2 if line_length else None)
+                "# | " + d for d in split_comment(self.descriptions, line_length - 2 if line_length else None)
             ]
             result.append(f"{self._name} = TypedDict('{self._name}', " + "{")
             for property_, type_obj in self.struct.items():
-                result += [f"    # {comment}" for comment in type_obj.comments()]
+                result += [f"    # | {comment}" for comment in type_obj.comments()]
                 result.append(f"    '{property_}': {type_obj.name()},")
             result.append("}, total=False)")
         return result

--- a/jsonschema_gentypes/__init__.py
+++ b/jsonschema_gentypes/__init__.py
@@ -438,7 +438,10 @@ class TypeAlias(NamedType):
         Return the type declaration.
         """
         result = ["", ""]
-        result.append(f"{self._name} = {self.sub_type.name()}")
+        _type = (
+            ": TypeAlias" if isinstance(self.sub_type, BuiltinType) and self.sub_type.name() == "None" else ""
+        )
+        result.append(f"{self._name}{_type} = {self.sub_type.name()}")
         comments = split_comment(self.comments(), line_length - 2 if line_length else None)
         if len(comments) == 1:
             result += [f'""" {comments[0]} """', ""]
@@ -446,6 +449,17 @@ class TypeAlias(NamedType):
             result += ['"""', *comments, '"""', ""]
 
         return result
+
+    def imports(self, python_version: tuple[int, ...]) -> list[tuple[str, str]]:
+        """
+        Return the needed imports.
+        """
+        del python_version
+        return (
+            [("typing", "TypeAlias")]
+            if isinstance(self.sub_type, BuiltinType) and self.sub_type.name() == "None"
+            else []
+        )
 
 
 class TypeEnum(NamedType):

--- a/jsonschema_gentypes/api.py
+++ b/jsonschema_gentypes/api.py
@@ -170,8 +170,13 @@ class API:
                 description.append("")
             description += additional_description
             if description:
-                if not isinstance(the_type, NamedType):
-                    if auto_alias:
+                if auto_alias:
+                    alias = True
+                    if isinstance(the_type, NamedType):
+                        alias = False
+                    elif isinstance(the_type, CombinedType):
+                        alias = not isinstance(the_type.base, NamedType)
+                    if alias:
                         the_type = TypeAlias(
                             self.get_name(schema_meta_data, proposed_name), the_type, description
                         )
@@ -205,8 +210,9 @@ class API:
         ],
         proposed_name: Optional[str] = None,
         upper: bool = False,
+        postfix: Optional[str] = None,
     ) -> str:
-        return get_name(schema, proposed_name, upper, self.get_name_properties)
+        return get_name(schema, proposed_name, upper, self.get_name_properties, postfix=postfix)
 
     def resolve_ref(
         self,

--- a/jsonschema_gentypes/api_draft_04.py
+++ b/jsonschema_gentypes/api_draft_04.py
@@ -99,7 +99,7 @@ class APIv4(API):
         )
 
         std_dict = None
-        name = self.get_name(schema_meta_data, proposed_name)
+
         schema.setdefault("used", set()).add("additionalProperties")  # type: ignore[typeddict-item]
         additional_properties = cast(
             Union[jsonschema_draft_04.JSONSchemaD4, jsonschema_draft_2020_12_applicator.JSONSchemaD2020],
@@ -150,8 +150,11 @@ class APIv4(API):
                 for prop, sub_schema in properties.items()
             }
 
+            name = self.get_name(
+                schema_meta_data, proposed_name, postfix="Typed" if std_dict is not None else ""
+            )
             type_: Type = TypedDictType(
-                name if std_dict is None else name + "Typed",
+                name,
                 struct,
                 get_description(schema_meta_data) if std_dict is None else [],
                 required=required,

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -8,18 +8,21 @@ from jsonschema_gentypes.api import Type
 
 
 def get_types(schema) -> Type:
+    jsonschema_gentypes.get_name.__dict__.setdefault("names", set()).clear()
     resolver = jsonschema_gentypes.resolver.RefResolver("https://example.com/fake", schema)
     api = jsonschema_gentypes.api_draft_07.APIv7(resolver)
     return api.get_type(schema, "Base")
 
 
 def get_types_2019_09(schema) -> Type:
+    jsonschema_gentypes.get_name.__dict__.setdefault("names", set()).clear()
     resolver = jsonschema_gentypes.resolver.RefResolver("https://example.com/fake", schema)
     api = jsonschema_gentypes.api_draft_2019_09.APIv201909(resolver)
     return api.get_type(schema, "Base")
 
 
 def get_types_2020_12(schema) -> Type:
+    jsonschema_gentypes.get_name.__dict__.setdefault("names", set()).clear()
     resolver = jsonschema_gentypes.resolver.RefResolver("https://example.com/fake", schema)
     api = jsonschema_gentypes.api_draft_2020_12.APIv202012(resolver)
     return api.get_type(schema, "Base")
@@ -971,10 +974,12 @@ foundation and establish self publication rules.
     ],
 )
 def test_name(config, title, expected):
+    jsonschema_gentypes.get_name.__dict__.setdefault("names", set()).clear()
     assert jsonschema_gentypes.get_name(config, title) == expected
 
 
 def test_name_upper():
+    jsonschema_gentypes.get_name.__dict__.setdefault("names", set()).clear()
     assert jsonschema_gentypes.get_name({"title": "test"}, upper=True) == "TEST"
 
 

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -590,7 +590,7 @@ def test_all_of_2() -> None:
         "\n".join([d.rstrip() for d in type_.definition(None)])
         == f'''
 
-TestBasicTypes = None
+TestBasicTypes: TypeAlias = None
 """ test basic types. """
 '''
     )


### PR DESCRIPTION
This PR addresses three issues reported in https://github.com/sbrunner/jsonschema-gentypes/issues/998.

The first commit resolves an issue with generating a valid `TypeAlias` per this [suggestion](https://github.com/sbrunner/jsonschema-gentypes/issues/998#issuecomment-2149022228).

The second commit resolves an issue with mypy parsing `type: ` in code blocks as a mypy directive (i.e. `type: ignore`) by inserting a `|` at the start of code blocks [per this suggestion](https://github.com/sbrunner/jsonschema-gentypes/issues/998#issuecomment-2145544802).

The third commit resolves an issue with duplicate type names by appending a random number to each generated type name [per this suggestion](https://github.com/sbrunner/jsonschema-gentypes/issues/998#issuecomment-2145773490).

Closes https://github.com/sbrunner/jsonschema-gentypes/issues/998