### PR TITLE
Fix CVE

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -4,5 +4,5 @@ setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerabil
 pip==23.3.2
 protobuf>=3.18.3 # not directly required, pinned by Snyk to avoid a vulnerability
 certifi>=2022.12.7 # not directly required, pinned by Snyk to avoid a vulnerability
-cryptography>=39.0.1 # not directly required, pinned by Snyk to avoid a vulnerability
+cryptography>=42.0.8 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.32.2 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 poetry==1.6.1
-cryptography>=41.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
+cryptography>=42.0.8 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.32.2 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
[LOW] cryptography@42.0.6: SNYK-PYTHON-CRYPTOGRAPHY-6913422 CWE-400 [Fixed in: 42.0.8].