### PR TITLE
[Backport 1.2] Fix CVE

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,7 +1,7 @@
 c2cciutils==1.2.18
 ruamel.yaml<0.18.0
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
-cryptography>=39.0.1 # not directly required, pinned by Snyk to avoid a vulnerability
+cryptography>=42.0.8 # not directly required, pinned by Snyk to avoid a vulnerability
 pyopenssl>=22.1.0
 requests>=2.32.2 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=1.26.19 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 poetry==1.6.1
 poetry-core>=1.1.0a7 # not directly required, pinned by Snyk to avoid a vulnerability
-cryptography>=41.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
+cryptography>=42.0.8 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.32.2 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=1.26.19 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
Backport of #1078

Error on cherry picking:
Error on backporting to branch 1.2, error on cherry picking 8d96f584796e5aff95a50d2dd285254f4fd1e3fa:



To continue do:
git fetch && git checkout backport/1078-to-1.2 && git reset --hard HEAD^
git cherry-pick 8d96f584796e5aff95a50d2dd285254f4fd1e3fa
git push origin backport/1078-to-1.2 --force