### PR TITLE
[Backport master] Fix publish

### DIFF
--- a/BACKPORT_TODO
+++ b/BACKPORT_TODO
@@ -1,0 +1,8 @@
+Error on backporting to branch master, error on cherry picking 205af9eb8079e256de21ad0d61f6b597108a2d41:
+
+
+
+To continue do:
+git fetch && git checkout backport/1164-to-master && git reset --hard HEAD^
+git cherry-pick 205af9eb8079e256de21ad0d61f6b597108a2d41
+git push origin backport/1164-to-master --force


### PR DESCRIPTION
Backport of #1164

Error on cherry picking:
Error on backporting to branch master, error on cherry picking 205af9eb8079e256de21ad0d61f6b597108a2d41:



To continue do:
git fetch && git checkout backport/1164-to-master && git reset --hard HEAD^
git cherry-pick 205af9eb8079e256de21ad0d61f6b597108a2d41
git push origin backport/1164-to-master --force