### PR TITLE
Added config option to load locally available references

### DIFF
--- a/jsonschema_gentypes/__init__.py
+++ b/jsonschema_gentypes/__init__.py
@@ -196,7 +196,7 @@ class TypeProxy(Type):
 
     def add_depends_on(self, depends_on: "Type") -> None:
         """Add a sub type."""
-        raise NotImplementedError
+        super().add_depends_on(depends_on)
 
     def comments(self) -> list[str]:
         """Additional comments shared by the type."""

--- a/jsonschema_gentypes/__init__.py
+++ b/jsonschema_gentypes/__init__.py
@@ -194,10 +194,6 @@ class TypeProxy(Type):
         assert self._type is not None
         return self._type.depends_on(python_version)
 
-    def add_depends_on(self, depends_on: "Type") -> None:
-        """Add a sub type."""
-        super().add_depends_on(depends_on)
-
     def comments(self) -> list[str]:
         """Additional comments shared by the type."""
         return self._type.comments() if self._type is not None else []

--- a/jsonschema_gentypes/cli.py
+++ b/jsonschema_gentypes/cli.py
@@ -194,6 +194,10 @@ def process_config(config: configuration.Configuration, files: list[str]) -> Non
             for vocab, uri in gen["vocabularies"].items():
                 resolver.add_vocabulary(vocab, uri)
 
+        if "local_resources" in gen:
+            for path in gen["local_resources"]:
+                resolver.add_local_resource(path)
+
         openapi = "openapi" in schema
         if "$schema" not in schema and openapi:
             api_version: Callable[..., Any] = jsonschema_gentypes.api_draft_2020_12.APIv202012

--- a/jsonschema_gentypes/configuration.py
+++ b/jsonschema_gentypes/configuration.py
@@ -107,6 +107,9 @@ class GenerateItem(TypedDict, total=False):
     Used to add some vocabularies
     """
 
+    local_resources: list[str]
+    """ Locally available resources. """
+
 
 GetNameProperties = Union[Literal["Title"], Literal["UpperFirst"]]
 """

--- a/jsonschema_gentypes/resolver.py
+++ b/jsonschema_gentypes/resolver.py
@@ -163,7 +163,8 @@ class RefResolver:
 
     def add_local_resource(self, content_path: Union[str, Path]) -> None:
         """Add some locally available resource to the registry."""
-        content = json.load(Path(content_path).open("r", encoding="utf-8"))
+        with Path(content_path).open("r", encoding="utf-8") as f:
+            content = json.load(f)
         self.registry = self.registry.with_contents([(content["$id"], content)])
 
     def lookup(
@@ -184,7 +185,13 @@ class RefResolver:
 
         exception = None
         if uri in self.registry:
-            return self.registry[uri].contents
+            return cast(
+                Union[
+                    jsonschema_draft_06.JSONSchemaItemD6,
+                    jsonschema_draft_2020_12_applicator.JSONSchemaItemD2020,
+                ],
+                self.registry[uri].contents,
+            )
         try:
             return self.resolver.lookup(uri).contents
         except (

--- a/jsonschema_gentypes/resolver.py
+++ b/jsonschema_gentypes/resolver.py
@@ -161,6 +161,11 @@ class RefResolver:
         self.vocabulary_url[vocab] = url
         self.vocabulary_resolver[vocab] = self.registry.resolver(url)
 
+    def add_local_resource(self, content_path: Union[str, Path]) -> None:
+        """Add some locally available resource to the registry."""
+        content = json.load(Path(content_path).open("r", encoding="utf-8"))
+        self.registry = self.registry.with_contents([(content["$id"], content)])
+
     def lookup(
         self,
         uri: str,
@@ -178,6 +183,8 @@ class RefResolver:
                 return self.resolver.lookup(f"{self.vocabulary_url[vocab]}#{path}").contents
 
         exception = None
+        if uri in self.registry:
+            return self.registry[uri].contents
         try:
             return self.resolver.lookup(uri).contents
         except (

--- a/jsonschema_gentypes/schema.json
+++ b/jsonschema_gentypes/schema.json
@@ -80,6 +80,11 @@
             "description": "Used to add some vocabularies",
             "type": "object",
             "additionalProperties": { "type": "string" }
+          },
+          "local_resources": {
+            "title": "Locally available resources",
+            "type": "array",
+            "items": { "type": "string" }
           }
         },
         "required": ["source", "destination"]


### PR DESCRIPTION
 instead of resolving them online
Closes #1301

The new config option `local_resources` is a mapping per json schema like this:
```yaml
generate:
  - source: foo.schema.json
    destination: foo.py
    api_arguments:
      additional_properties: Only explicit
    local_resources:
      - bar.schema.json
```
Which adds `bar.schema.json` to the schema registry (the key is the "$id" of `bar.schema.json`) thus removing the need to resolve the uri if `foo.schema.json` references it.